### PR TITLE
Fixed TileMoveController being null problem

### DIFF
--- a/IGME302_Project2/Assets/Prefabs/Enemies.meta
+++ b/IGME302_Project2/Assets/Prefabs/Enemies.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbe205c151b1e5140ab543e11ec980d4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IGME302_Project2/Assets/Scripts/MovingEntity.cs
+++ b/IGME302_Project2/Assets/Scripts/MovingEntity.cs
@@ -23,21 +23,28 @@ public class MovingEntity : MonoBehaviour, IMovable
             if (TileMoveController) { return TileMoveController.OnMove; }
             else
             {
-                Debug.LogError("Cannot get OnMove; TileMoveController is null.");
-                return null;
+                if (targetFollower.Target)
+                {
+                    TileMoveController = targetFollower.Target.GetComponent<TilemapMovementController>();
+                    return TileMoveController.OnMove;
+                }
             }
+
+            return null;
         }
         set
         {
             if (TileMoveController) { TileMoveController.OnMove = value; }
             else
             {
-                Debug.LogError("Cannot set OnMove; TileMoveController is null.");
+                if (targetFollower.Target)
+                {
+                    TileMoveController = targetFollower.Target.GetComponent<TilemapMovementController>();
+                    TileMoveController.OnMove = value;
+                }
             }
         }
     }
-
-    public Action OnMoveControllerSetup;
 
     protected virtual void Awake()
     {
@@ -59,8 +66,14 @@ public class MovingEntity : MonoBehaviour, IMovable
             targetFollower.Target = newTarget.transform;
             // Attach a TilemapMovementController to all moving entities' target
             if (targetFollower.Target)
-                TileMoveController = targetFollower.Target.gameObject.AddComponent(typeof(TilemapMovementController)) as TilemapMovementController;
-            OnMoveControllerSetup?.Invoke();
+            {
+                targetFollower.Target.gameObject.AddComponent(typeof(TilemapMovementController));
+                TileMoveController = targetFollower.Target.GetComponent<TilemapMovementController>();
+            }
+            else
+            {
+                Debug.Log("reached!!!");
+            }
         }
     }
 
@@ -85,5 +98,10 @@ public class MovingEntity : MonoBehaviour, IMovable
             transform.position = (Vector3)position;
             TileMoveController.MoveTo(position);
         }
+    }
+
+    private void OnDisable()
+    {
+        OnMove = null;
     }
 }


### PR DESCRIPTION
Now any time TileMoveController is trying to be accessed and it comes back as null, it will be lazily instantiated inside that get or set method.